### PR TITLE
Add RSS feed

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -100,6 +100,16 @@ module.exports = withBundleAnalyzer({
       ],
     })
 
+    if (!options.dev && options.isServer) {
+      const originalEntry = config.entry
+
+      config.entry = async () => {
+        const entries = { ...(await originalEntry()) }
+        entries['./scripts/build-rss.js'] = './scripts/build-rss.js'
+        return entries
+      }
+    }
+
     return config
   },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6811,6 +6811,33 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -8531,6 +8558,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build && next export && npm run build:rss",
     "start": "next start",
-    "build:rss": "node ./.next/server/scripts/build-rss.js && cp ./.next/static/feed.xml ./out/feed.xml"
+    "build:rss": "node ./.next/server/scripts/build-rss.js"
   },
   "dependencies": {
     "@mapbox/rehype-prism": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
-    "start": "next start"
+    "build": "next build && next export && npm run build:rss",
+    "start": "next start",
+    "build:rss": "node ./.next/server/scripts/build-rss.js && cp ./.next/static/feed.xml ./out/feed.xml"
   },
   "dependencies": {
     "@mapbox/rehype-prism": "^0.5.0",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@next/bundle-analyzer": "^9.4.4",
     "file-loader": "^6.0.0",
+    "rss": "^1.2.2",
     "simple-functional-loader": "^1.2.1"
   }
 }

--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -19,4 +19,4 @@ getAllPostPreviews().forEach(({ link, module: { meta } }) => {
   })
 })
 
-fs.writeFileSync('./.next/static/feed.xml', feed.xml({ indent: true }))
+fs.writeFileSync('./out/feed.xml', feed.xml({ indent: true }))

--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -1,0 +1,22 @@
+import fs from 'fs'
+import RSS from 'rss'
+import getAllPostPreviews from '../src/getAllPostPreviews'
+
+const feed = new RSS({
+  title: 'Blog – Tailwind CSS',
+  site_url: 'https://blog.tailwindcss.com',
+  feed_url: 'https://blog.tailwindcss.com/feed.xml',
+})
+
+getAllPostPreviews().forEach(({ link, module: { meta } }) => {
+  feed.item({
+    title: meta.title,
+    guid: link,
+    url: `https://blog.tailwindcss.com${link}`,
+    date: meta.date,
+    description: meta.description,
+    custom_elements: [].concat(meta.authors.map((author) => ({ author: [{ name: author.name }] }))),
+  })
+})
+
+fs.writeFileSync('./.next/static/feed.xml', feed.xml({ indent: true }))

--- a/src/getAllPostPreviews.js
+++ b/src/getAllPostPreviews.js
@@ -1,7 +1,10 @@
 function importAll(r) {
   return r
     .keys()
-    .map((fileName) => ({ link: fileName.replace(/\/index\.mdx$/, ''), module: r(fileName) }))
+    .map((fileName) => ({
+      link: fileName.substr(1).replace(/\/index\.mdx$/, ''),
+      module: r(fileName),
+    }))
 }
 
 function dateSortDesc(a, b) {

--- a/src/getStaticProps.js
+++ b/src/getStaticProps.js
@@ -5,7 +5,7 @@ export async function getStaticProps() {
     props: {
       posts: getAllPostPreviews().map((post) => ({
         title: post.module.meta.title,
-        link: post.link.substr(1),
+        link: post.link,
       })),
     },
   }


### PR DESCRIPTION
The implementation is basically from [this article](https://logana.dev/blog/rss-feeds-in-a-nextjs-site) and how it's done on the [Next.js website](https://github.com/vercel/next-site).

- `scripts/build-rss.js` is a simple node script that generates the feed and saves it to the build output folder (`/out`)
- In `next.config.js` the `build-rss` script is added as an entry point so that it goes through the webpack build process
- A new `build:rss` npm script runs the compiled script (now in `/.next/server/scripts`)