### PR TITLE
Fix misspelling of the word 'argument'

### DIFF
--- a/src/pages/tailwindcss-1-5/index.mdx
+++ b/src/pages/tailwindcss-1-5/index.mdx
@@ -36,7 +36,7 @@ While these are still much more useful for utilities than any other type of clas
 </article>
 ```
 
-You can take advantage of this feature in your own component classes by using the new `variants` option in the second argumant of the `addComponents` plugin API:
+You can take advantage of this feature in your own component classes by using the new `variants` option in the second argument of the `addComponents` plugin API:
 
 ```js
 plugin(function ({ addComponents })) {


### PR DESCRIPTION
Hey Adam, love the work you do with Tailwind CSS, just noticed this typo on your recent blog post.

Hope this helps,
Duane